### PR TITLE
feat: 284781 - Update schema for createCdo - add opt country

### DIFF
--- a/app/schema/ddi-index-api/cdo/create.js
+++ b/app/schema/ddi-index-api/cdo/create.js
@@ -9,7 +9,8 @@ const schema = Joi.object({
       addressLine1: Joi.string().required(),
       addressLine2: Joi.string().optional().allow('').allow(null),
       town: Joi.string().required(),
-      postcode: Joi.string().required()
+      postcode: Joi.string().required(),
+      country: Joi.string().optional().allow('').allow(null)
     }).required()
   }).required(),
   enforcementDetails: Joi.object({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aphw-ddi-portal",
-  "version": "0.81.4",
+  "version": "0.82.4",
   "description": "Web frontend for managing the dogs index",
   "homepage": "https://github.com/DEFRA/aphw-ddi-portal",
   "main": "app/index.js",

--- a/test/contract/aphw-ddi-api.test.js
+++ b/test/contract/aphw-ddi-api.test.js
@@ -1,39 +1,98 @@
 const Matchers = require('@pact-foundation/pact/dsl/matchers')
 const { ddiIndexApiProvider } = require('./mockServices')
-let countriesApi
-
+const { valid: validCdo, validWithCountry } = require('../mocks/cdo/createPayload')
+const { userWithDisplayname } = require('../mocks/auth')
+const { validCdoMatcher, validCdoMatcherWithCountry } = require('./matchers/cdo')
+const CdoCreatedViewModel = require('../../app/models/cdo/create/record-created')
 describe('API service contract test', () => {
   describe('/countries', () => {
+    let countriesApi
+
     beforeAll(async () => {
       const mockService = ddiIndexApiProvider
       await mockService.setup()
       jest.mock('../../app/config', () => ({
         ddiIndexApi: mockService.mockService
       }))
-      countriesApi = require('../../app/api/ddi-index-api/countries')
     })
 
-    test('GET /countries', async () => {
-      await ddiIndexApiProvider.addInteraction({
-        state: 'countries exist',
-        uponReceiving: 'get all countries',
-        withRequest: {
-          method: 'GET',
-          path: '/countries'
-        },
-        willRespondWith: {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8'
-          },
-          body: {
-            countries: Matchers.eachLike('England', null)
-          }
-        }
+    describe('GET /countries', () => {
+      beforeAll(() => {
+        countriesApi = require('../../app/api/ddi-index-api/countries')
       })
 
-      const response = await countriesApi.getCountries()
-      expect(response[0]).toEqual('England')
+      test('GET /countries', async () => {
+        await ddiIndexApiProvider.addInteraction({
+          state: 'countries exist',
+          uponReceiving: 'get all countries',
+          withRequest: {
+            method: 'GET',
+            path: '/countries'
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8'
+            },
+            body: {
+              countries: Matchers.eachLike('England', null)
+            }
+          }
+        })
+
+        const response = await countriesApi.getCountries()
+        expect(response[0]).toEqual('England')
+      })
+    })
+
+    describe('/cdo', () => {
+      let cdoApi
+
+      beforeAll(() => {
+        cdoApi = require('../../app/api/ddi-index-api/cdo')
+      })
+
+      test('POST /cdo with mandatory data', async () => {
+        await ddiIndexApiProvider.addInteraction({
+          state: 'cdo has only mandatory data',
+          uponReceiving: 'submission to POST cdo data',
+          withRequest: {
+            method: 'POST',
+            path: '/cdo'
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8'
+            },
+            body: validCdoMatcher
+          }
+        })
+
+        const response = await cdoApi.createCdo(validCdo, userWithDisplayname)
+        expect(() => CdoCreatedViewModel(response)).not.toThrow()
+      })
+
+      test('POST /cdo with optional data including country', async () => {
+        await ddiIndexApiProvider.addInteraction({
+          state: 'cdo includes optional data and country',
+          uponReceiving: 'submission to POST cdo data',
+          withRequest: {
+            method: 'POST',
+            path: '/cdo'
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8'
+            },
+            body: validCdoMatcherWithCountry
+          }
+        })
+
+        const response = await cdoApi.createCdo(validWithCountry, userWithDisplayname)
+        expect(() => CdoCreatedViewModel(response)).not.toThrow()
+      })
     })
   })
 

--- a/test/contract/matchers/cdo.js
+++ b/test/contract/matchers/cdo.js
@@ -1,0 +1,58 @@
+const { term, eachLike, like, string, iso8601Date } = require('@pact-foundation/pact/dsl/matchers')
+const { anyIntegerString } = require('./custom')
+
+const validCdoMatcher = {
+  owner: {
+    firstName: string('Shaun'),
+    lastName: string('Fitzsimons'),
+    address: like({
+      addressLine1: '14 Fake Street',
+      town: string('City of London'),
+      postcode: string('E1 7AA')
+    })
+  },
+  enforcementDetails: {
+    legislationOfficer: string('Joe Bloggs'),
+    policeForce: anyIntegerString('1'),
+    court: anyIntegerString('1')
+  },
+  dogs: eachLike({
+    breed: string('Pit Bull Terrier'),
+    name: string(''),
+    applicationType: term({ generate: 'cdo', matcher: 'cdo|Interim Exemption' })
+  })
+}
+
+const validCdoMatcherWithCountry = {
+  owner: {
+    firstName: string('Homer'),
+    lastName: string('Simpson'),
+    dateOfBirth: iso8601Date('1998-05-10'),
+    address: {
+      addressLine1: string('1 Anywhere St'),
+      addressLine2: string('Anywhere Estate'),
+      town: string('Pontypridd'),
+      postcode: string('CF15 7SU'),
+      country: term({ generate: 'Wales', matcher: 'England|Scotland|Wales' })
+    }
+  },
+  enforcementDetails: {
+    court: anyIntegerString('1'),
+    policeForce: anyIntegerString('1'),
+    legislationOfficer: string('Sidney Lewis')
+  },
+  dogs: [
+    {
+      breed: string('XL Bully'),
+      name: string('Rex'),
+      applicationType: term({ generate: 'cdo', matcher: 'cdo|Interim Exemption' }),
+      cdoIssued: iso8601Date('2023-10-10'),
+      cdoExpiry: iso8601Date('2023-12-10')
+    }
+  ]
+}
+
+module.exports = {
+  validCdoMatcher,
+  validCdoMatcherWithCountry
+}

--- a/test/contract/matchers/custom.js
+++ b/test/contract/matchers/custom.js
@@ -1,0 +1,6 @@
+const { term } = require('@pact-foundation/pact/dsl/matchers')
+const anyIntegerString = (generate) => term({ generate, matcher: '^([1-9][0-9]*)$' })
+
+module.exports = {
+  anyIntegerString
+}

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -5,9 +5,16 @@ const user = {
   username: 'test@example.com'
 }
 
+const userWithDisplayname = {
+  userId: '1',
+  username: 'test@example.com',
+  displayname: 'Example Tester'
+}
+
 const auth = { strategy: 'session-auth', credentials: { scope: [admin], account: { user } } }
 
 module.exports = {
   user,
-  auth
+  auth,
+  userWithDisplayname
 }

--- a/test/mocks/cdo/createPayload.js
+++ b/test/mocks/cdo/createPayload.js
@@ -32,6 +32,35 @@ const valid = {
   ]
 }
 
+const validWithCountry = {
+  owner: {
+    firstName: 'Homer',
+    lastName: 'Simpson',
+    dateOfBirth: '1998-05-10',
+    address: {
+      addressLine1: '1 Anywhere St',
+      addressLine2: 'Anywhere Estate',
+      town: 'Pontypridd',
+      postcode: 'CF15 7SU',
+      country: 'Wales'
+    }
+  },
+  enforcementDetails: {
+    court: '1',
+    policeForce: '1',
+    legislationOfficer: 'Sidney Lewis'
+  },
+  dogs: [
+    {
+      breed: 'XL Bully',
+      name: 'Rex',
+      applicationType: 'cdo',
+      cdoIssued: '2023-10-10',
+      cdoExpiry: '2023-12-10'
+    }
+  ]
+}
+
 const invalid = {
   owner: {
     dateOfBirth: '1998-05-10',
@@ -65,5 +94,6 @@ const invalid = {
 
 module.exports = {
   valid,
+  validWithCountry,
   invalid
 }

--- a/test/unit/api/ddi-index-api/cdo.test.js
+++ b/test/unit/api/ddi-index-api/cdo.test.js
@@ -4,7 +4,7 @@ describe('CDO API endpoints', () => {
 
   const { cdo } = require('../../../../app/api/ddi-index-api')
 
-  const { valid, invalid } = require('../../../mocks/cdo/createPayload')
+  const { valid, invalid, validWithCountry } = require('../../../mocks/cdo/createPayload')
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -19,6 +19,12 @@ describe('CDO API endpoints', () => {
 
   test('createCdo with valid payload should post to API', async () => {
     await cdo.createCdo(valid)
+
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  test('createCdo with valid payload including country should post to API', async () => {
+    await cdo.createCdo(validWithCountry)
 
     expect(post).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
Adds a new schema for cdo calls and contract test to validate against on api side